### PR TITLE
Wmbubble.1x

### DIFF
--- a/wmbubble.1x
+++ b/wmbubble.1x
@@ -96,19 +96,19 @@ Displays this help
 Draw the duck?
 .TP
 .B \-d
-Equivalent to -duck no
+Equivalent to \-duck no
 .TP
 .B \-upsidedown
 Can the duck flip when the tank is overfull?
 .TP
 .B \-u
-Equivalent to -upsidedown no
+Equivalent to \-upsidedown no
 .TP
 .B \-cpumeter
 Show the current load at the bottom
 .TP
 .B \-c
-Equivalent to -cpumeter no
+Equivalent to \-cpumeter no
 .TP
 .B \-graphdigit
 Color of the digits on the graphs
@@ -141,13 +141,13 @@ Adjust the digit colors to pale blue and cyan
 Does hovering show the graphs
 .TP
 .B \-m
-Equivalent to -graphs no
+Equivalent to \-graphs no
 .TP
 .B \-units
 Units for memory in KB or MB
 .TP
 .B \-k
-Equivalent to -units megabytes
+Equivalent to \-units megabytes
 .TP
 .B \-shifttime
 Number of hours after midnight that are drawn as part of the previous day on digital clock and date


### PR DESCRIPTION
This branch will fix following:

```
I: wmbubble: hyphen-used-as-minus-sign usr/share/man/man1/wmbubble.1x.gz:99
I: wmbubble: hyphen-used-as-minus-sign usr/share/man/man1/wmbubble.1x.gz:105
I: wmbubble: hyphen-used-as-minus-sign usr/share/man/man1/wmbubble.1x.gz:111
I: wmbubble: hyphen-used-as-minus-sign usr/share/man/man1/wmbubble.1x.gz:144
I: wmbubble: hyphen-used-as-minus-sign usr/share/man/man1/wmbubble.1x.gz:150
```

Please also rename *.1x manual page to simple *.1. After pulling my other branch, change install code in debian/manpages to match *.1
