### PR TITLE
Add several fixes to make wmbubble work on Debian GNU/kFreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,13 @@ ifeq ($(OS), FreeBSD)
 	INSTALL = -c -g kmem -m 2755 -o root
 endif
 
+ifeq ($(OS), GNU/kFreeBSD)
+	OBJS += sys_freebsd.o
+	LIBS = -lX11 -lkvm -lm
+	INSTALL = -c -g kmem -m 2755 -o root
+	CFLAGS += -D_BSD_SOURCE
+endif
+
 # special things for NetBSD
 ifeq ($(OS), NetBSD)
 	OBJS += sys_netbsd.o

--- a/bubblemon.c
+++ b/bubblemon.c
@@ -404,7 +404,7 @@ int main(int argc, char **argv) {
 
 	argv++; argc--; /* Otherwise we'll make more of ourselves on a left click */
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 	if (init_stuff())
 		exit(-1);
 #endif

--- a/include/sys_include.h
+++ b/include/sys_include.h
@@ -24,4 +24,8 @@ int system_cpu(void);		/* return total CPU load in percent */
 void system_memory(void);	/* set memory related values in BubbleMonData */
 void system_loadavg(void);	/* get current load average and put into
 				   bm->loadavg[].{i,f} */
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+int init_stuff();
+#endif
+
 #endif /* _SYS_INCLUDE_H_ */


### PR DESCRIPTION
In particular:
- recognize GNU/kFreeBSD as an option in the Makefile
- call init_stuff if **FreeBSD_kernel** is defined instead of just **FreeBSD**
- use sysctl instead of kvm_read for system_cpu; inspired by FreeBSD patch for
  wmcube-gdk by KOIE Hidetaka (http://lists.freebsd.org/pipermail/freebsd-ports-bugs/2008-January/135006.html)
