### PR TITLE
Fix multiple definitions of global variables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ ifneq (,)
 This makefile requires GNU Make.
 endif
 
-INSTALL = -m 755
+INSTALL = install
+INSTFLAGS = -m 755
 VERSION = $(shell git describe --tags)
 
 # where to install this program
@@ -46,7 +47,7 @@ endif
 ifeq ($(OS), NetBSD)
 	OBJS += sys_netbsd.o
 	LIBS = -lX11 -lkvm -lm
-	INSTALL = -c -g kmem -m 2755 -o root
+	INSTFLAGS = -c -g kmem -m 2755 -o root
 endif
 
 # special things for OpenBSD
@@ -90,10 +91,10 @@ clean:
 	rm -f wmbubble *.o *.bb* *.gcov gmon.* *.da *~
 
 install: wmbubble wmbubble.1
-	install -m 755 -d $(DESTDIR)$(PREFIX)/bin
-	install $(INSTALL) wmbubble $(DESTDIR)$(PREFIX)/bin
-	install -m 755 -d $(DESTDIR)$(PREFIX)/share/man/man1
-	install -m 644 wmbubble.1 $(DESTDIR)$(PREFIX)/share/man/man1
+	$(INSTALL) -m 755 -d $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) $(INSTFLAGS) wmbubble $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) -m 755 -d $(DESTDIR)$(PREFIX)/share/man/man1
+	$(INSTALL) -m 644 wmbubble.1 $(DESTDIR)$(PREFIX)/share/man/man1
 
 dist-tar:
 	git archive -v -9 --prefix=wmbubble-$(VERSION)/ master \

--- a/wmx11pixmap.c
+++ b/wmx11pixmap.c
@@ -13,6 +13,10 @@
 #include <sys/types.h>
 #include "wmx11pixmap.h"
 
+/* Global variables necessary for the event handlers */
+Display *wmxp_display;
+Window  wmxp_iconwin, wmxp_win;
+
 /* Private variables */
 GC      NormalGC;
 Pixmap  wmgen;

--- a/wmx11pixmap.h
+++ b/wmx11pixmap.h
@@ -26,7 +26,7 @@ void RGBtoXIm(const unsigned char * from, XImage * ximout);
 }
 
 /* Global variables necessary for the event handlers */
-Display *wmxp_display;
-Window  wmxp_iconwin, wmxp_win;
+extern Display *wmxp_display;
+extern Window  wmxp_iconwin, wmxp_win;
 
 #endif


### PR DESCRIPTION
The `wmxp_display`, `wmxp_iconwin` and `wmxp_win` variables are declared
in wmx11pixmap.h with no explicit linkage.  This results in there being
definitions of them in multiple object-files and may cause link failures
when building with GCC 10, since this uses -fno-common by default.

Add `extern` to the header declarations and separate declaration with no
linkage in wmx11pixmap.c where they are initialized.

Link: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=957939
Signed-off-by: Jeremy Sowden <jeremy@azazel.net>