### PR TITLE
Fix multiple definitions of global variables.

### DIFF
--- a/wmx11pixmap.c
+++ b/wmx11pixmap.c
@@ -13,6 +13,10 @@
 #include <sys/types.h>
 #include "wmx11pixmap.h"
 
+/* Global variables necessary for the event handlers */
+Display *wmxp_display;
+Window  wmxp_iconwin, wmxp_win;
+
 /* Private variables */
 GC      NormalGC;
 Pixmap  wmgen;

--- a/wmx11pixmap.h
+++ b/wmx11pixmap.h
@@ -26,7 +26,7 @@ void RGBtoXIm(const unsigned char * from, XImage * ximout);
 }
 
 /* Global variables necessary for the event handlers */
-Display *wmxp_display;
-Window  wmxp_iconwin, wmxp_win;
+extern Display *wmxp_display;
+extern Window  wmxp_iconwin, wmxp_win;
 
 #endif


### PR DESCRIPTION
The `wmxp_display`, `wmxp_iconwin` and `wmxp_win` variables are declared
in wmx11pixmap.h with no explicit linkage.  This results in there being
definitions of them in multiple object-files and may cause link failures
when building with GCC 10, since this uses -fno-common by default.

Add `extern` to the header declarations and separate declaration with no
linkage in wmx11pixmap.c where they are initialized.

Link: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=957939
Signed-off-by: Jeremy Sowden <jeremy@azazel.net>