### PR TITLE
Rename `INSTALL` variable to `INSTFLAGS` and add a new `INSTALL`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ ifneq (,)
 This makefile requires GNU Make.
 endif
 
-INSTALL = -m 755
+INSTALL = install
+INSTFLAGS = -m 755
 VERSION = $(shell git describe --tags)
 
 # where to install this program
@@ -46,7 +47,7 @@ endif
 ifeq ($(OS), NetBSD)
 	OBJS += sys_netbsd.o
 	LIBS = -lX11 -lkvm -lm
-	INSTALL = -c -g kmem -m 2755 -o root
+	INSTFLAGS = -c -g kmem -m 2755 -o root
 endif
 
 # special things for OpenBSD
@@ -90,10 +91,10 @@ clean:
 	rm -f wmbubble *.o *.bb* *.gcov gmon.* *.da *~
 
 install: wmbubble wmbubble.1
-	install -m 755 -d $(DESTDIR)$(PREFIX)/bin
-	install $(INSTALL) wmbubble $(DESTDIR)$(PREFIX)/bin
-	install -m 755 -d $(DESTDIR)$(PREFIX)/share/man/man1
-	install -m 644 wmbubble.1 $(DESTDIR)$(PREFIX)/share/man/man1
+	$(INSTALL) -m 755 -d $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) $(INSTFLAGS) wmbubble $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) -m 755 -d $(DESTDIR)$(PREFIX)/share/man/man1
+	$(INSTALL) -m 644 wmbubble.1 $(DESTDIR)$(PREFIX)/share/man/man1
 
 dist-tar:
 	git archive -v -9 --prefix=wmbubble-$(VERSION)/ master \


### PR DESCRIPTION
variable that contains the install command to use.

`INSTALL` has traditionally been used to hold the install command to
use.  The GNU make manual, for example, says this:

  Every Makefile should define the variable INSTALL, which is the basic
  command for installing a file into the system.

(https://www.gnu.org/software/make/manual/make.html#Command-Variables)

Debian's debhelper tool sets this variable when building packages, which
results in build failures, since:

  install $(INSTALL) wmbubble $(DESTDIR)$(PREFIX)/bin

expands to:

  install install --strip-program=true wmbubble ...

Signed-off-by: Jeremy Sowden <jeremy@azazel.net>